### PR TITLE
Make autorun behaviour configurable

### DIFF
--- a/src/dom-ready.js
+++ b/src/dom-ready.js
@@ -13,5 +13,7 @@ var DOMReady = function(f) {
 DOMReady(function() {
 
     // Called each time on script load
-    iframely.trigger('load');
+    if (typeof iframely.config.autorun === 'undefined' || iframely.config.autorun !== false) {
+        iframely.trigger('load');
+    }
 });


### PR DESCRIPTION
This is useful if you’re unable to selectively load the script itself – say because your build process bundles vendor scripts – but you’d still like to determine where and when embeds should be processed.